### PR TITLE
Add Content-Type header

### DIFF
--- a/icontrollx/hello-bigip/README.md
+++ b/icontrollx/hello-bigip/README.md
@@ -6,7 +6,7 @@ Example of a simple iControlLX plugin to create a range of nodes
     $ curl -k -u user:pass https://[bigip]/mgmt/Nodes
     # returns all the ltm nodes
 
-    $ curl -k -u user:pass http://[bigip]/mgmt/Nodes -d '{ "start": "192.168.1.0", "end": "192.168.1.10" }'
+    $ curl -k -u user:pass http://[bigip]/mgmt/Nodes -d '{ "start": "192.168.1.0", "end": "192.168.1.10" }' -H 'Content-Type: application/json'
 
     $ curl -k -u user:pass https://[bigip]/mgmt/Nodes
     # returns all nodes including new ones


### PR DESCRIPTION
Without the Content-Type header set to application/json the following error will be encountered:

{"code":500,"message":"body needs 'start' and 'end' values","referer":"172.18.41.152","originalRequestBody":"\"{ \\\"start\\\": \\\"192.168.1.0\\\", \\\"end\\\": \\\"192.168.1.10\\\" }\"","errorSt